### PR TITLE
Fix deprecation errors in Atom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 node_modules
 
 tst.js
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "scripts": {
-    "build": "./node_modules/coffescript/bin/coffee grammars/dogescript.coffee > grammars/dogescript.cson"
+    "build": "coffee grammars/dogescript.coffee > grammars/dogescript.cson"
   },
   "devDependencies": {
     "atom-syntax-tools": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "build": "coffee grammars/dogescript.coffee > grammars/dogescript.cson"
   },
   "devDependencies": {
-    "atom-syntax-tools": "^0.9.1"
-  }
+    "atom-syntax-tools": "^0.9.1",
+    "coffeescript": "^2.0.2"
+  },
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "scripts": {
-    "build": "coffee grammars/dogescript.coffee > grammars/dogescript.cson"
+    "build": "./node_modules/coffescript/bin/coffee grammars/dogescript.coffee > grammars/dogescript.cson"
   },
   "devDependencies": {
     "atom-syntax-tools": "^0.9.1",

--- a/styles/dogescript.atom-text-editor.less
+++ b/styles/dogescript.atom-text-editor.less
@@ -1,11 +1,10 @@
 @import "syntax-variables";
 
-.source.dogescript {
-  .keyword.operator.assignment.dogescript {
+.syntax--source.syntax--dogescript {
+  .syntax--keyword.syntax--operator.syntax--assignment.syntax--dogescript {
     color: @syntax-color-keyword;
   }
-  .keyword.operator.words.dogescript {
+  .syntax--keyword.syntax--operator.syntax--words.syntax--dogescript {
       color: @syntax-color-keyword;
   }
 }
- 


### PR DESCRIPTION
Atom, since version 1.1.13 has been giving deprecation errors regarding the shadowing/colliding namespace. It wanted things prefixed with `syntax--`. I've updated those for the `.less` file.